### PR TITLE
Fix DB creation when running dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -16,6 +16,8 @@ source "$venv_dir/bin/activate"
 echo "📦 Installing requirements..."
 pip install -r requirements.txt
 
+cd src/
+
 # Create the database if it does not exist yet
 if [ ! -e "database.db" ]; then
     echo "Database file not found. Creating the database..."
@@ -24,7 +26,6 @@ if [ ! -e "database.db" ]; then
     set +x
 fi
 
-cd src/
 
 echo ""
 echo "✨ Starting the application at http://localhost:3000"


### PR DESCRIPTION
The `dev.sh` script does not create the DB file correctly since the creation script "scripts.create_db" is accessible within the "src/" directory, but not from the project root directly.

We fix the `dev.sh` script so DB file creation works correctly.