### PR TITLE
Allow cashing out more than total buyin

### DIFF
--- a/src/game/route.py
+++ b/src/game/route.py
@@ -213,15 +213,16 @@ def handle_cashout_form(player: Player) -> Response:
     if not game_player:
         return redirect(url_for('home'))
 
-    cashout_max_cents = get_max_cashout_cents(active_game_players, game_player)
-    cashout_max = cents_utils.to_string(cashout_max_cents)
-
     if game_player.cashout_cents:
-        cashout_prefill = cents_utils.to_string(game_player.cashout_cents)
+        cashout_prefill = cents_utils.to_numerical_string(
+                game_player.cashout_cents)
     else:
         cashout_prefill = ""
 
-    return render_template('game/cashout.html', cashout_max=cashout_max, cashout_max_cents=cashout_max_cents, cashout_prefill=cashout_prefill, game=active_game, player=player)
+    return render_template('game/cashout.html',
+                           cashout_prefill=cashout_prefill,
+                           game=active_game,
+                           player=player)
 
 
 def handle_cashout(player: Player, socketio: SocketIO) -> Response:
@@ -240,17 +241,18 @@ def handle_cashout(player: Player, socketio: SocketIO) -> Response:
         return redirect(url_for('home'))
 
     err = None
-    cashout_max_cents = get_max_cashout_cents(active_game_players, game_player)
     cents = get_cents_form_param('amount')
 
-    if cents > cashout_max_cents:
-        err = f'You can only cash out at most {cents_utils.to_string(cashout_max_cents)}'
-    elif cents < 0:
+    if cents < 0:
         err = 'Please provide a valid amount to cash out'
 
     if err:
         cashout_prefill = cents_utils.to_string(cents)
-        return render_template('game/cashout.html', err=err, cashout_prefill=cashout_prefill, game=active_game, player=player), 400
+        return render_template('game/cashout.html',
+                               err=err,
+                               cashout_prefill=cashout_prefill,
+                               game=active_game,
+                               player=player), 400
 
     game_players_repository.cash_out(game_id, player_id, cents)
     game_players_repository.remove_player(game_id, player_id)

--- a/src/templates/game/cashout.html
+++ b/src/templates/game/cashout.html
@@ -11,7 +11,7 @@
         {% endif %}
         <form class="form" action="/game/cashout" method="post">
             <label for="amount">Please enter the amount to cash out:</label>
-            <input autofocus="number" inputmode="decimal" name="amount" step="0.01" min="0.00" max="{{ cashout_max }}"
+            <input autofocus="number" inputmode="decimal" name="amount" step="0.01" min="0.00"
                 value="{{ cashout_prefill }}" placeholder="0.00">
             <div class="form-buttons">
                 <input type="submit" value="Cash Out">


### PR DESCRIPTION
Allow cash out to be greater than total buy-in since, which can occur when
 * Game winners cash out before everyone has bought in
 * There has been some user error