### PR TITLE
Fix floating point bug

### DIFF
--- a/src/tests/test_utils_cents.py
+++ b/src/tests/test_utils_cents.py
@@ -117,6 +117,9 @@ class TestCents(unittest.TestCase):
         c = from_string("20.01")
         self.assertEqual(c, 2001)
 
+        c = from_string("20.2")
+        self.assertEqual(c, 2020)
+
 
     def test_from_string_failure(self):
         c = from_string("abcd")

--- a/src/utils/cents.py
+++ b/src/utils/cents.py
@@ -32,6 +32,8 @@ def from_string(s :str) -> Optional[int]:
     """
     try:
         dollars, _, cents = s.partition('.')
+        while len(cents) < 2:
+            cents += '0'
         dollars = int(dollars or 0)
         cents = int(cents or 0)
 


### PR DESCRIPTION
Fix floating bug where converting string to number of cents fails.
i.e. "20.5" -> 2005 cents when the correct answer is 2050

We fix the bug by padding char '0' to the cents during the processing.

Closes issue: https://github.com/brianhang/pokerpals/issues/16