### PR TITLE
Fix completed payments not showing in payments list

### DIFF
--- a/src/game/route.py
+++ b/src/game/route.py
@@ -183,7 +183,7 @@ def handle_view_game(player: Optional[Player], game_id: int) -> Response:
         player_payments = [
             payment for payment in payments
             if (player.venmo_username == payment.from_player_id or
-            player.venmo_username == payment.to_player_id) and
+                player.venmo_username == payment.to_player_id) and
             not payment.completed
         ]
         payment_and_urls = get_payment_and_urls(player, player_payments)

--- a/src/game/route.py
+++ b/src/game/route.py
@@ -175,15 +175,16 @@ def handle_view_game(player: Optional[Player], game_id: int) -> Response:
     buyin_total = cents_utils.to_string(req_game_players.total_buyin_cents())
     cashout_total = cents_utils.to_string(
         req_game_players.total_cashout_cents())
-    payments = payment_repository.fetch_for_game(game_id, only_incomplete=True)
+    payments = payment_repository.fetch_for_game(game_id)
 
     payment_and_urls = []
 
     if player:
         player_payments = [
             payment for payment in payments
-            if player.venmo_username == payment.from_player_id or
-            player.venmo_username == payment.to_player_id
+            if (player.venmo_username == payment.from_player_id or
+            player.venmo_username == payment.to_player_id) and
+            not payment.completed
         ]
         payment_and_urls = get_payment_and_urls(player, player_payments)
 

--- a/src/payment/repository.py
+++ b/src/payment/repository.py
@@ -81,7 +81,7 @@ def fetch_for_player(
                 from_player_id=row[2],
                 to_player_id=row[3],
                 cents=row[4],
-                completed=row[5]
+                completed=bool(row[5])
             ))
 
     return payments


### PR DESCRIPTION
Payments that were dismissed did not show at the bottom of the game view. This causes confusions because this was not the old behavior. This was a regression from https://github.com/brianhang/pokerpals/commit/e726f1827b065443d6d51dfae82c4b18c381273c.

Tested by:
1. Creating a game
2. Have two players join
3. Have one player owe the other
4. Dismiss the payment
5. Check the request/send does not display, but the bottom payment still does in the game page