### PR TITLE
Allow using comma as delimiter for cents

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,14 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "python.formatting.provider": "none"
+    "python.testing.cwd": "./src",
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
 }

--- a/src/tests/test_payout_settle.py
+++ b/src/tests/test_payout_settle.py
@@ -11,7 +11,10 @@ class TestSettle(unittest.TestCase):
         game_players = self.make_players([])
         transactions = get_transactions(game_players)
         self.assertListEqual(
-            [], transactions, 'There should be no transactions with no players')
+            [],
+            transactions,
+            'There should be no transactions with no players',
+        )
 
     def test_no_op(self):
         game_players = self.make_players([(0, 0)])
@@ -57,7 +60,10 @@ class TestSettle(unittest.TestCase):
         transactions = get_transactions(game_players)
         self.assert_transactions_valid(game_players, transactions)
 
-    def make_players(self, buyin_and_cashouts: list[tuple[int, Optional[int]]]) -> list[GamePlayer]:
+    def make_players(
+        self,
+        buyin_and_cashouts: list[tuple[int, Optional[int]]],
+    ) -> list[GamePlayer]:
         join_time = datetime.now()
         return [
             GamePlayer(
@@ -66,10 +72,15 @@ class TestSettle(unittest.TestCase):
                 buyin_cents=buyin_cents,
                 cashout_cents=cashout_cents
             )
-            for player_idx, (buyin_cents, cashout_cents) in enumerate(buyin_and_cashouts)
+            for player_idx, (buyin_cents, cashout_cents)
+            in enumerate(buyin_and_cashouts)
         ]
 
-    def assert_transactions_valid(self, game_players: list[GamePlayer], transactions: list[Transaction]) -> None:
+    def assert_transactions_valid(
+        self,
+        game_players: list[GamePlayer],
+        transactions: list[Transaction],
+    ) -> None:
         balances = {
             player.player_venmo_username: player.buyin_cents
             for player in game_players

--- a/src/tests/test_payout_settle.py
+++ b/src/tests/test_payout_settle.py
@@ -3,14 +3,15 @@ from typing import Optional
 import unittest
 
 from game_players.game_players import GamePlayer
-from .settle import get_transactions, Transaction
+from payout.settle import get_transactions, Transaction
 
 
 class TestSettle(unittest.TestCase):
     def test_empty(self):
         game_players = self.make_players([])
         transactions = get_transactions(game_players)
-        self.assertListEqual([], transactions, 'There should be no transactions with no players')
+        self.assertListEqual(
+            [], transactions, 'There should be no transactions with no players')
 
     def test_no_op(self):
         game_players = self.make_players([(0, 0)])
@@ -23,7 +24,8 @@ class TestSettle(unittest.TestCase):
         self.assertListEqual([], transactions, 'No transactions are necessary')
 
     def test_no_op_nonzero_many(self):
-        game_players = self.make_players([(10_00, 10_00), (20_00, 20_00), (0, 0)])
+        game_players = self.make_players(
+            [(10_00, 10_00), (20_00, 20_00), (0, 0)])
         transactions = get_transactions(game_players)
         self.assertListEqual([], transactions, 'No transactions are necessary')
 

--- a/src/tests/test_utils_cents.py
+++ b/src/tests/test_utils_cents.py
@@ -2,6 +2,7 @@ import unittest
 
 from utils.cents import to_numerical_string, to_string, from_string
 
+
 class TestCents(unittest.TestCase):
     def test_to_numerical_string(self):
         s = to_numerical_string(0)
@@ -91,7 +92,6 @@ class TestCents(unittest.TestCase):
         s = to_string(-1234)
         self.assertEqual(s, "-$12.34")
 
-
     def test_from_string(self):
         c = from_string("0")
         self.assertEqual(c, 0)
@@ -120,7 +120,6 @@ class TestCents(unittest.TestCase):
         c = from_string("20.2")
         self.assertEqual(c, 2020)
 
-
     def test_from_string_failure(self):
         c = from_string("abcd")
         self.assertEqual(c, None)
@@ -136,3 +135,7 @@ class TestCents(unittest.TestCase):
 
         c = from_string("0.100")
         self.assertEqual(c, None)
+
+    def test_from_string_comma_delimiter(self):
+        c = from_string("1,23")
+        self.assertEqual(c, 123)

--- a/src/utils/cents.py
+++ b/src/utils/cents.py
@@ -25,19 +25,25 @@ def to_string(tot_cents: int) -> str:
         return '-$'+s[1:]
     return '$'+s
 
-def from_string(s :str) -> Optional[int]:
+
+def from_string(s: str) -> Optional[int]:
     """
     Converts the input string in the format "XXX.XX" to an integer representing
     number of cents.  None is returned if the string can not be parsed.
     """
     try:
-        dollars, _, cents = s.partition('.')
+        if ',' in s:
+            dollars, _, cents = s.partition(',')
+        else:
+            dollars, _, cents = s.partition('.')
+
         while len(cents) < 2:
             cents += '0'
         dollars = int(dollars or 0)
         cents = int(cents or 0)
 
-        if cents < 0 or cents >= 100: return None
+        if cents < 0 or cents >= 100:
+            return None
 
         amt = abs(dollars) * 100 + cents
         if dollars < 0:


### PR DESCRIPTION
For people whose number input shows a comma instead of a period